### PR TITLE
Add NetworkConnection enumeration

### DIFF
--- a/ELReachability/NetworkStatus.swift
+++ b/ELReachability/NetworkStatus.swift
@@ -41,7 +41,7 @@ public struct NetworkStatusInterpreter {
     /// The actual flags reported by the system. This is used to compute if the network is reachable.
     public let flags: SCNetworkReachabilityFlags
 
-    /// The network connection type, or `nil` if the network is not reachable.
+    /// The network connection type, or `nil` if the network is not reachable. Note: This property may give false negatives.
     public let connection: NetworkConnection?
 
     internal init(flags: SCNetworkReachabilityFlags) {

--- a/ELReachability/NetworkStatus.swift
+++ b/ELReachability/NetworkStatus.swift
@@ -16,8 +16,7 @@ internal func objc_startMonitoring(_: SCNetworkReachability, _: dispatch_block_t
 internal func objc_stopMonitoring(_: SCNetworkReachability) -> ObjCBool
 
 /// The network connection enumeration describes the possible connection types that can be identified.
-@objc(ELNetworkConnection)
-public enum NetworkConnection : Int {
+public enum NetworkConnection {
     case cellular, wifi
 
     init?(flags: SCNetworkReachabilityFlags) {

--- a/ELReachability/NetworkStatus.swift
+++ b/ELReachability/NetworkStatus.swift
@@ -15,31 +15,55 @@ internal func objc_startMonitoring(_: SCNetworkReachability, _: dispatch_block_t
 @_silgen_name("objc_stopMonitoring")
 internal func objc_stopMonitoring(_: SCNetworkReachability) -> ObjCBool
 
+/// The network connection enumeration describes the possible connection types that can be identified.
+@objc(ELNetworkConnection)
+public enum NetworkConnection : Int {
+    case cellular, wifi
+
+    init?(flags: SCNetworkReachabilityFlags) {
+        if !flags.contains(.Reachable) {
+            return nil
+        }
+
+        // Check that this is not an oddity as per https://github.com/tonymillion/Reachability/blob/master/Reachability.m
+        if flags.contains(.ConnectionRequired) || flags.contains(.TransientConnection) {
+            return nil
+        }
+
+        if flags.contains(.IsWWAN) {
+            self = .cellular
+        } else {
+            self = .wifi
+        }
+    }
+}
+
 public struct NetworkStatusInterpreter {
     /// The actual flags reported by the system. This is used to compute if the network is reachable.
     public let flags: SCNetworkReachabilityFlags
-    
+
+    /// The network connection type, or `nil` if the network is not reachable.
+    public let connection: NetworkConnection?
+
+    internal init(flags: SCNetworkReachabilityFlags) {
+        self.flags = flags
+        self.connection = NetworkConnection(flags: flags)
+    }
+
     /// Returns `true` when the network is reachable. `false` otherwise.
     public var isReachable: Bool {
-        var isReachable = flags.contains(SCNetworkReachabilityFlags.Reachable)
-        
-        // Check that this is not an oddity as per https://github.com/tonymillion/Reachability/blob/master/Reachability.m
-        if flags.contains(SCNetworkReachabilityFlags.ConnectionRequired) || flags.contains(SCNetworkReachabilityFlags.TransientConnection) {
-            isReachable = false
-        }
-        return isReachable
+        return connection != nil
     }
     
     /// Returns `true` when the network is reachable via a cellular connection. `false` otherwise. Note: This check may give false negatives.
     public var isCellular: Bool {
-        return flags.contains(SCNetworkReachabilityFlags.IsWWAN)
+        return connection == .cellular
     }
     
     /// Returns `true` when the network is reachable via a WiFi connection. `false` otherwise. Note: This check may give false negatives.
     public var isWiFi: Bool {
-        return self.isReachable && !self.isCellular
+        return connection == .wifi
     }
-    
 }
 
 public typealias NetworkStatusCallbackClosure = (networkStatusInterpreter: NetworkStatusInterpreter) -> Void
@@ -104,6 +128,11 @@ public final class NetworkStatus: NSObject {
     }
     
     // MARK: Synchronous API methods
+
+    /// The current network connection type, or `nil` if the network is not reachable.
+    public var connection: NetworkConnection? {
+        return self.networkStatusInterpreter.connection
+    }
     
     /// Returns `true` when the network is reachable. `false` otherwise. Calls corresponding method in `NetworkStatusInterpreter`.
     public func isReachable() -> Bool {

--- a/ELReachabilityExample/ViewController.swift
+++ b/ELReachabilityExample/ViewController.swift
@@ -12,35 +12,46 @@ import ELReachability
 class ViewController: UIViewController {
     let theInternets: NetworkStatus?
 
+    required init?(coder aDecoder: NSCoder) {
+        theInternets = NetworkStatus.networkStatusForInternetConnection()
+
+        super.init(coder: aDecoder)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         // Set up a callback
-        if let theInternets = theInternets {
-            theInternets.startNetworkStatusMonitoring { (reachable) -> Void in
-                print("[Callback] Is Reachable: \(reachable.isReachable)")
-                print("[Callback] Is Cellular : \(reachable.isCellular)")
-                print("[Callback] Is WiFi : \(reachable.isWiFi)")
+        theInternets?.startNetworkStatusMonitoring { status in
+            guard let connection = status.connection else {
+                print("Internet is not reachable")
+                return
+            }
+
+            switch connection {
+            case .cellular:
+                print("Internet is reachable via cellular conneciton")
+            case .wifi:
+                print("Internet is reachable via WiFi conneciton")
             }
         }
     }
 
-    required init?(coder aDecoder: NSCoder) {
-        theInternets = NetworkStatus.networkStatusForInternetConnection()
-        
-        super.init(coder: aDecoder)
-    }
-    
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
-    }
-
     @IBAction func checkNetworkStatus() {
-        if let theInternets = theInternets {
-            print("[Synchronous] Is Reachable: \(theInternets.isReachable())")
-            print("[Synchronous] Is Cellular : \(theInternets.isCellular())")
-            print("[Synchronous] Is WiFi : \(theInternets.isWiFi())")
+        guard let theInternets = theInternets else {
+            return
+        }
+
+        guard let connection = theInternets.connection else {
+            print("[Synchronous] Internet is not reachable")
+            return
+        }
+
+        switch connection {
+        case .cellular:
+            print("[Synchronous] Internet is reachable via cellular conneciton")
+        case .wifi:
+            print("[Synchronous] Internet is reachable via WiFi conneciton")
         }
     }
 

--- a/ELReachabilityTests/ELReachabilityTests.swift
+++ b/ELReachabilityTests/ELReachabilityTests.swift
@@ -7,10 +7,17 @@
 //
 
 import XCTest
+import SystemConfiguration
 @testable import ELReachability
 
 class ELReachabilityTests: XCTestCase {
-    
+    // Examples of various "real world" flag combinations.
+    let offlineFlags: SCNetworkReachabilityFlags = []
+    let notConnectedFlags: SCNetworkReachabilityFlags = [.Reachable, .ConnectionRequired]
+    let transientFlags: SCNetworkReachabilityFlags = [.Reachable, .TransientConnection]
+    let cellularFlags: SCNetworkReachabilityFlags = [.Reachable, .IsWWAN]
+    let wifiFlags: SCNetworkReachabilityFlags = [.Reachable]
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -30,12 +37,53 @@ class ELReachabilityTests: XCTestCase {
             XCTAssert(false, "Failed")
         }
     }
-    
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measureBlock {
-            // Put the code you want to measure the time of here.
-        }
+
+    // MARK: NetworkConnection Tests
+
+    func testConnectionWhenNotReachable() {
+        XCTAssertNil(NetworkConnection(flags: offlineFlags), "Connection should be nil when offline")
+        XCTAssertNil(NetworkConnection(flags: notConnectedFlags), "Connection should be nil when not connected")
+        XCTAssertNil(NetworkConnection(flags: transientFlags), "Connection should be nil when transient")
     }
-    
+
+    func testConnectionWhenReachable() {
+        XCTAssertEqual(NetworkConnection(flags: cellularFlags), .cellular, "Connection should be `cellular` when connected via Cellular")
+        XCTAssertEqual(NetworkConnection(flags: wifiFlags), .wifi, "Connection should be `wifi` when connected via WiFi")
+    }
+
+    // MARK: NetworkStatusInterpreter Tests
+
+    func testInterpreterWhenNotReachable() {
+        let offline = NetworkStatusInterpreter(flags: offlineFlags)
+        XCTAssertFalse(offline.isReachable, "Status should be not-reachable when offline")
+        XCTAssertNil(offline.connection, "Connection should be nil when offline")
+        XCTAssertFalse(offline.isCellular, "`isCellular` should be false when offline")
+        XCTAssertFalse(offline.isWiFi, "`isWiFi` should be false when offline")
+
+        let notConnected = NetworkStatusInterpreter(flags: notConnectedFlags)
+        XCTAssertFalse(notConnected.isReachable, "Status should be not-reachable when not connected")
+        XCTAssertNil(notConnected.connection, "Connection should be nil when not connected")
+        XCTAssertFalse(notConnected.isCellular, "`isCellular` should be false when not connected")
+        XCTAssertFalse(notConnected.isWiFi, "`isWiFi` should be false when not connected")
+
+        let transient = NetworkStatusInterpreter(flags: transientFlags)
+        XCTAssertFalse(transient.isReachable, "Status should be not-reachable when transient")
+        XCTAssertNil(transient.connection, "Connection should be nil when transient")
+        XCTAssertFalse(transient.isCellular, "`isCellular` should be false when transient")
+        XCTAssertFalse(transient.isWiFi, "`isWiFi` should be false when transient")
+    }
+
+    func testInterpreterWhenReachable() {
+        let cellular = NetworkStatusInterpreter(flags: cellularFlags)
+        XCTAssertTrue(cellular.isReachable, "Status should be reachable when connected via Cellular")
+        XCTAssertEqual(cellular.connection, .cellular, "Connection should be `cellular` when connected via Cellular")
+        XCTAssertTrue(cellular.isCellular, "`isCellular` should be true when connected via Cellular")
+        XCTAssertFalse(cellular.isWiFi, "`isWiFi` should be false when connected via Cellular")
+
+        let wifi = NetworkStatusInterpreter(flags: wifiFlags)
+        XCTAssertTrue(wifi.isReachable, "Status should be reachable when connected via WiFi")
+        XCTAssertEqual(wifi.connection, .wifi, "Connection should be `wifi` when connected via WiFi")
+        XCTAssertTrue(wifi.isWiFi, "`isWiFi` should true when connected via WiFi")
+        XCTAssertFalse(wifi.isCellular, "`isCellular` should be false when connected via WiFi")
+    }
 }

--- a/README.md
+++ b/README.md
@@ -11,18 +11,34 @@
 
 Setting up and checking reachability to the internet
 
-```Swift
+```swift
 // Create a Reachability instance
 let theInternets = NetworkStatus.networkStatusForInternetConnection()
 
 // Set up a callback
-theInternets.startNetworkStatusMonitoring { (reachable) -> Void in
-    println("Internet reachability: \(reachable.isReachable)")
-    println("Using celular: \(reachable.isCellular)")
+theInternets.startNetworkStatusMonitoring { status in
+    guard let connection = status.connection else {
+        print("Internet is not reachable")
+        return
+    }
+
+    switch connection {
+        case .cellular:
+            print("Internet is reachable via cellular connection")
+        case .wifi:
+            print("Internet is reachable via WiFi connection")
+    }
 }
 
 // Synchronous check
-println("Reachability to internet: \(theInternets.reachable.isReachable)")
+switch theInternets.connection {
+    case nil:
+        print("Internet is not reachable")
+    case .cellular?:
+        print("Internet is reachable via cellular connection")
+    case .wifi?:
+        print("Internet is reachable via WiFi connection")
+}
 
 // Stop monitoring
 theInternets.stopNetworkStatusMonitoring()


### PR DESCRIPTION
#### What does this PR do?

Adds a new enumeration type, `NetworkConnection`, to represent the type of connection that is currently available.
#### Any background context you want to provide?

This is meant to address issue #4. In that issue, I had suggested adding a "reachability" type, with values for offline, cellular and WiFi connections. Instead, I chose to model this as a "connection" type, where "offline" is represented by `nil`, and "cellular" and "WiFi" are represented by values.

By introducing a new property, I was able to maintain full backwards compatibility in the API.

Because the property is an optional value type, the `connection` property is not available to objc.
